### PR TITLE
feat: add plainText prop for plain-text email editing mode

### DIFF
--- a/.changeset/plain-text-mode.md
+++ b/.changeset/plain-text-mode.md
@@ -1,0 +1,10 @@
+---
+"capsule-editor": minor
+---
+
+Add plainText prop for plain-text email editing mode
+
+- New `plainText` prop on `<Editor>` disables HTML linting and syntax highlighting when `true`
+- Passes `{ htmlLinting: false }` to capsule-lint so FreeMarker errors still surface but HTML-specific errors (spec-char-escape, tag-pair, etc.) are suppressed
+- Skips the CodeMirror HTML language extension in plain-text mode to avoid HTML-specific autocomplete and folding
+- Bumps `capsule-lint` peer dependency requirement to `^0.6.0`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Build
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@vue-interface/btn": "^5.0.5",
     "@vue-interface/btn-dropdown": "^4.1.6",
     "@vue-interface/dropdown-menu": "^3.0.8",
-    "capsule-lint": "^0.5.4",
+    "capsule-lint": "^0.6.0",
     "cm6-theme-basic-dark": "^0.2.0",
     "thememirror": "^2.0.1",
     "vue": "^3.5.31"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8(vue@3.5.31(typescript@5.9.3))
       capsule-lint:
-        specifier: ^0.5.4
-        version: 0.5.4(peggy@3.0.2)
+        specifier: ^0.6.0
+        version: 0.6.0(peggy@3.0.2)
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -1095,8 +1095,8 @@ packages:
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
-  capsule-lint@0.5.4:
-    resolution: {integrity: sha512-SzXMK90pD78Y78r5kB5qAgLfyru87ZjF18KICv+AKznAJ93vipUH3hkIc3AcFAlMZEvTuGPIOhd/vAKdHcf/eA==}
+  capsule-lint@0.6.0:
+    resolution: {integrity: sha512-JXLvEKXHlcvlP1pZBUDhPE7ISP6ysX+ALq4zggS0S4NElyb8z33bJShqlAEH8qJJ+GCu+q5eT3wQYtL76yXabg==}
     hasBin: true
 
   chalk@4.1.2:
@@ -3301,7 +3301,7 @@ snapshots:
 
   caniuse-lite@1.0.30001781: {}
 
-  capsule-lint@0.5.4(peggy@3.0.2):
+  capsule-lint@0.6.0(peggy@3.0.2):
     dependencies:
       htmlhint: 1.9.2
       ts-pegjs: 4.2.1(peggy@3.0.2)

--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -22,8 +22,9 @@ const props = withDefaults(defineProps<{
     filename?: string;
     footer?: boolean;
     indent?: string;
+    plainText?: boolean;
     ruleset?: CapsuleRuleset;
-    saveButton?: boolean; 
+    saveButton?: boolean;
     theme?: Extension;
     title?: string;
     toolbar?: boolean;
@@ -34,6 +35,7 @@ const props = withDefaults(defineProps<{
     filename: undefined,
     footer: true,
     indent: '    ',
+    plainText: false,
     ruleset: undefined,
     saveButton: true,
     theme: () => basicDark,
@@ -95,14 +97,14 @@ function initialize() {
             defaultTheme,
             themeConfig.of([ props.theme ]),
             footerPlugin,
-            props.footer && lint(footerRef.value, Object.assign({}, defaultConfig, props.ruleset)),
+            props.footer && lint(footerRef.value, Object.assign({}, defaultConfig, props.ruleset), { htmlLinting: !props.plainText }),
             indentUnit.of(props.indent),
             lineNumbers(),
             highlightActiveLineGutter(),
             highlightSpecialChars(),
             highlightSelectionMatches(),
             history(),
-            html({
+            !props.plainText && html({
                 autoCloseTags: true,
                 matchClosingTags: false
             }),

--- a/src/plugins/Lint.ts
+++ b/src/plugins/Lint.ts
@@ -2,7 +2,7 @@ import type { Action as LintAction } from '@codemirror/lint';
 import { Diagnostic, lintGutter, linter } from '@codemirror/lint';
 import { StateEffect } from '@codemirror/state';
 import { EditorView, showPanel } from '@codemirror/view';
-import { lint, type CapsuleRuleset, type Hint } from 'capsule-lint';
+import { lint, type CapsuleRuleset, type Hint, type LintOptions } from 'capsule-lint';
 import EditorFooter from 'src/EditorFooter.vue';
 import actions from '../actions';
 
@@ -12,12 +12,12 @@ export type Action = LintAction & {
 
 const setDiagnosticsEffect = StateEffect.define<Diagnostic[]>();
 
-export default function(footer: typeof EditorFooter, ruleset?: CapsuleRuleset) {
+export default function(footer: typeof EditorFooter, ruleset?: CapsuleRuleset, options?: LintOptions) {
     return [
         linter(view => {
             const { doc } = view.state.toJSON();
-                
-            const diagnostics = lint(doc, ruleset).map((error: Hint) => {
+
+            const diagnostics = lint(doc, ruleset, options).map((error: Hint) => {
                 const pos = view.state.doc.line(error.line);
                 const from  = Math.min(doc.length, pos.from - 1 + error.col);
                 const to = Math.min(doc.length, from + error.raw.length);


### PR DESCRIPTION
## Summary
- New `plainText` boolean prop on `<Editor>` enables plain-text email editing mode
- When `true`, passes `{ htmlLinting: false }` to capsule-lint — FreeMarker errors still surface but HTML-specific errors (spec-char-escape, tag-pair, etc.) are suppressed
- Skips the CodeMirror HTML language extension in plain-text mode (no HTML autocomplete or tag folding)
- Bumps `capsule-lint` peer dependency to `^0.6.0`
- Adds CI workflow that runs `pnpm build` on PRs to master

## Usage
```vue
<!-- HTML email (default) -->
<Editor :content="html" />

<!-- Plain-text email -->
<Editor :content="text" :plain-text="true" />
```

## Test plan
- [ ] CI build passes
- [ ] `plainText=false` (default): HTML linting errors appear, HTML syntax highlighting active
- [ ] `plainText=true`: no HTML errors for `<<gift array>>` or unmatched tags; FreeMarker errors still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)