### PR TITLE
fix: replace unresolvable <btn> with <button> in EditorFooter

### DIFF
--- a/.changeset/fix-editor-footer-btn-element.md
+++ b/.changeset/fix-editor-footer-btn-element.md
@@ -1,0 +1,7 @@
+---
+"capsule-editor": patch
+---
+
+Fix unresolvable `<btn>` component in EditorFooter
+
+The save button in `EditorFooter` used `<btn>` which is not a registered Vue component, causing a `[Vue warn]: Failed to resolve component: btn` console warning. Changed to the native `<button>` element.

--- a/src/EditorFooter.vue
+++ b/src/EditorFooter.vue
@@ -178,13 +178,13 @@ defineExpose({
                     name="save-button"
                     :diagnostics="diagnostics"
                     :save-button-label="diagnostics">
-                    <btn
+                    <button
                         v-if="saveButton && !diagnostics.length"
                         type="button"
                         class="btn btn-primary"
                         @click="emit('save')">
                         {{ saveButtonLabel }}
-                    </btn>
+                    </button>
                 </slot>
 
                 <slot


### PR DESCRIPTION
## Summary

- The save button in `EditorFooter.vue` used `<btn>` which is not a registered Vue component
- This produced `[Vue warn]: Failed to resolve component: btn` in the browser console on every render
- Changed to the native `<button>` element, which is what was clearly intended (it already had `type="button"` and `class="btn btn-primary"`)

## Test plan

- [ ] Verify no `Failed to resolve component: btn` warning in the browser console
- [ ] Verify the Save button in the editor footer renders and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)