### PR TITLE
chore: bump capsule-lint to ^0.6.3

### DIFF
--- a/.changeset/bump-capsule-lint-0.6.3.md
+++ b/.changeset/bump-capsule-lint-0.6.3.md
@@ -1,0 +1,5 @@
+---
+"capsule-editor": patch
+---
+
+Bump `capsule-lint` peer dependency to `^0.6.3`.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vue-interface/btn": "^5.0.5",
     "@vue-interface/btn-dropdown": "^4.1.6",
     "@vue-interface/dropdown-menu": "^3.0.8",
-    "capsule-lint": "^0.6.0",
+    "capsule-lint": "^0.6.3",
     "cm6-theme-basic-dark": "^0.2.0",
     "thememirror": "^2.0.1",
     "vue": "^3.5.31"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8(vue@3.5.31(typescript@5.9.3))
       capsule-lint:
-        specifier: ^0.6.0
-        version: 0.6.0(peggy@3.0.2)
+        specifier: ^0.6.3
+        version: 0.6.3
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -838,9 +838,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@ts-morph/common@0.19.0':
-    resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1095,8 +1092,8 @@ packages:
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
-  capsule-lint@0.6.0:
-    resolution: {integrity: sha512-JXLvEKXHlcvlP1pZBUDhPE7ISP6ysX+ALq4zggS0S4NElyb8z33bJShqlAEH8qJJ+GCu+q5eT3wQYtL76yXabg==}
+  capsule-lint@0.6.3:
+    resolution: {integrity: sha512-CgUkEF2kCMaSPGfS784Fyeoyr+/I9NP1dyLSQePFHocjGZfD8vbM17xMOr3U58DqBH28W+9VKRBMLOOkicXfoA==}
     hasBin: true
 
   chalk@4.1.2:
@@ -1129,19 +1126,12 @@ packages:
       '@codemirror/view': ^6.0.0
       '@lezer/highlight': ^1.0.0
 
-  code-block-writer@12.0.0:
-    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1728,21 +1718,12 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@7.4.9:
-    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
-    engines: {node: '>=10'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp@2.1.6:
-    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1850,11 +1831,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  peggy@3.0.2:
-    resolution: {integrity: sha512-n7chtCbEoGYRwZZ0i/O3t1cPr6o+d9Xx4Zwy2LYfzv0vjchMBU0tO+qYYyvZloBPcgRgzYvALzGWHe609JjEpg==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1956,10 +1932,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  source-map-generator@0.8.0:
-    resolution: {integrity: sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==}
-    engines: {node: '>= 10'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2031,15 +2003,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-morph@18.0.0:
-    resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
-
-  ts-pegjs@4.2.1:
-    resolution: {integrity: sha512-mK/O2pu6lzWUeKpEMA/wsa0GdYblfjJI1y0s0GqH6xCTvugQDOWPJbm5rY6AHivpZICuXIriCb+a7Cflbdtc2w==}
-    hasBin: true
-    peerDependencies:
-      peggy: ^3.0.2
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2989,13 +2952,6 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.7(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
 
-  '@ts-morph/common@0.19.0':
-    dependencies:
-      fast-glob: 3.3.3
-      minimatch: 7.4.9
-      mkdirp: 2.1.6
-      path-browserify: 1.0.1
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -3301,12 +3257,9 @@ snapshots:
 
   caniuse-lite@1.0.30001781: {}
 
-  capsule-lint@0.6.0(peggy@3.0.2):
+  capsule-lint@0.6.3:
     dependencies:
       htmlhint: 1.9.2
-      ts-pegjs: 4.2.1(peggy@3.0.2)
-    transitivePeerDependencies:
-      - peggy
 
   chalk@4.1.2:
     dependencies:
@@ -3337,15 +3290,11 @@ snapshots:
       '@codemirror/view': 6.40.0
       '@lezer/highlight': 1.2.3
 
-  code-block-writer@12.0.0: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  commander@10.0.1: {}
 
   commander@11.1.0: {}
 
@@ -3919,15 +3868,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@7.4.9:
-    dependencies:
-      brace-expansion: 5.0.5
-
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  mkdirp@2.1.6: {}
 
   mri@1.2.0: {}
 
@@ -4021,11 +3964,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  peggy@3.0.2:
-    dependencies:
-      commander: 10.0.1
-      source-map-generator: 0.8.0
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4113,8 +4051,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  source-map-generator@0.8.0: {}
-
   source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
@@ -4172,17 +4108,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  ts-morph@18.0.0:
-    dependencies:
-      '@ts-morph/common': 0.19.0
-      code-block-writer: 12.0.0
-
-  ts-pegjs@4.2.1(peggy@3.0.2):
-    dependencies:
-      peggy: 3.0.2
-      prettier: 2.8.8
-      ts-morph: 18.0.0
 
   tslib@2.8.1:
     optional: true


### PR DESCRIPTION
## Summary
- Bumps `capsule-lint` peer dependency from `^0.6.0` to `^0.6.3`

## Test plan
- [ ] Verify the editor builds and functions correctly with the updated peer dependency range

🤖 Generated with [Claude Code](https://claude.com/claude-code)