### PR TITLE
fix: honor the extensions prop in the editor config

### DIFF
--- a/.changeset/honor-extensions-prop.md
+++ b/.changeset/honor-extensions-prop.md
@@ -1,0 +1,5 @@
+---
+"capsule-editor": patch
+---
+
+Honor the `extensions` prop. It was declared but never applied to the editor's `EditorView` config, so consumer-supplied extensions were silently ignored. They're now spread into the config with precedence over the editor's defaults, allowing built-ins to be reconfigured (e.g. docking the search panel to the top via `search({ top: true })`).

--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -96,6 +96,10 @@ function initialize() {
         extensions: [
             defaultTheme,
             themeConfig.of([ props.theme ]),
+            // Consumer-supplied extensions take precedence over the editor's
+            // defaults, so they can reconfigure built-ins (e.g. search panel
+            // placement) rather than only append to them.
+            ...props.extensions,
             footerPlugin,
             props.footer && lint(footerRef.value, Object.assign({}, defaultConfig, props.ruleset), { htmlLinting: !props.plainText }),
             indentUnit.of(props.indent),


### PR DESCRIPTION
## Problem

`Editor.vue` declares an `extensions?: Extension[]` prop (defaulted to `() => []`) but never spreads it into the `EditorView` configuration. As a result, any consumer-supplied extensions are silently ignored.

This surfaced when trying to dock the CodeMirror search/replace panel to the top of the editor via `:extensions="[search({ top: true })]"` — the prop had no effect, and the panel stayed at the bottom (the editor's hardcoded `search()`).

## Fix

Spread `...props.extensions` into the extension list, placed high in the precedence order (right after the theme) so consumer extensions can **reconfigure** the editor's built-ins (e.g. search panel placement) rather than only append to them.

## Notes

- `dist/` is gitignored and rebuilt by the release workflow; only source + a changeset are included here.
- A patch changeset is included to trigger a `Version Packages` release PR on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)